### PR TITLE
feat: Add Dockerization for client application

### DIFF
--- a/.github/workflows/client-docker-build.yml
+++ b/.github/workflows/client-docker-build.yml
@@ -1,0 +1,43 @@
+name: Build and Push Client Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'client/**' # Trigger only if files in client/ or its Dockerfile/workflow change
+      - '.github/workflows/client-docker-build.yml'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  build-and-push-client: # Job name specific to client
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the code
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Client Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./client # Context is the client directory
+          file: ./client/Dockerfile # Path to the client's Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ping-client:latest # Example image name, user can customize
+          # To add more tags, like git sha:
+          # tags: |
+          #   ${{ secrets.DOCKERHUB_USERNAME }}/ping-client:latest
+          #   ${{ secrets.DOCKERHUB_USERNAME }}/ping-client:${{ github.sha }}
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -191,9 +191,39 @@ The client is a static Javascript application that makes API calls to the BFF.
 ## Deployment
 
 ### Client Application (`/client`)
-*   The client application is configured to be built and deployed to **GitHub Pages** automatically.
-*   This is handled by the GitHub Actions workflow defined in `.github/workflows/client-deploy.yml`.
-*   Deployment happens on pushes to the `main` branch (if changes are detected in the `client/` directory or the workflow file).
+
+The client application can be deployed in two ways:
+
+1.  **GitHub Pages (Static Deployment):**
+    *   The client application is configured to be built and deployed to **GitHub Pages** automatically.
+    *   This is handled by the GitHub Actions workflow defined in `.github/workflows/client-deploy.yml`.
+    *   Deployment happens on pushes to the `main` branch (if changes are detected in the `client/` directory or the workflow file).
+    *   The live URL will be something like `https://julesclements.github.io/mixed/`.
+
+2.  **Docker Container (Static Serve):**
+    *   The client application can also be built into a Docker container that serves its static files using the `serve` package.
+    *   A `client/Dockerfile` is provided for this.
+    *   **Local Docker Build & Run:**
+        *   To build the image locally:
+            ```bash
+            docker build -t yourdockerhubusername/ping-client:latest client/
+            ```
+            (Replace `yourdockerhubusername` with your Docker Hub username or any desired image name).
+        *   To run the container locally:
+            ```bash
+            docker run -d -p 8080:8080 yourdockerhubusername/ping-client:latest
+            ```
+            The client will then be accessible at `http://localhost:8080`.
+    *   **Automated Docker Build (GitHub Actions):**
+        *   The `.github/workflows/client-docker-build.yml` workflow automatically builds and pushes the client's Docker image to Docker Hub.
+        *   This happens on pushes to `main` if files in the `client/` directory or the `client-docker-build.yml` workflow file itself are changed.
+        *   The image is tagged as `yourdockerhubusername/ping-client:latest` (or similar, based on the workflow and secrets).
+        *   **Required GitHub Secrets:** For this workflow to push to Docker Hub, you must configure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in your GitHub repository secrets.
+    *   **Client Configuration (`bffBaseUrl` when containerized):**
+        *   When the client is run from its Docker container and accessed (e.g., via `http://localhost:8080` locally), the `bffBaseUrl` in `client/script.js` will be determined by `window.location.hostname`.
+        *   If accessed via `localhost`, it will attempt to connect to the BFF at `http://localhost:3001` (as per current `script.js` logic).
+        *   If the BFF is also running in a Docker container locally, ensure Docker networking allows communication (e.g., by using a shared Docker network or ensuring the BFF's port is mapped to the host).
+        *   For deployed scenarios (e.g., client container hosted, BFF at `https://mixed.hdc.company`), the client's `bffBaseUrl` logic should correctly point to the production BFF URL if the client is accessed via its production hostname (e.g., `julesclements.github.io` or a custom domain).
 
 ### BFF Application (`/bff`)
 *   The BFF application is designed to be run as a **Docker container**.

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,37 @@
+# Stage 1: Build the static assets
+FROM node:20-slim AS builder
+
+WORKDIR /app/client
+
+# Copy package.json and package-lock.json (if available)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the client application source code
+COPY . .
+
+# Build the application
+# The output will be in the /app/client/docs directory (as per parcel build script)
+RUN npm run build
+
+# Stage 2: Serve the static assets from the 'docs' directory
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+# Install 'serve' to serve static files
+RUN npm install -g serve
+
+# Copy the built assets from the builder stage
+COPY --from=builder /app/client/docs ./docs
+
+# Expose the port 'serve' will listen on (default for serve is 3000, but can be overridden)
+# Let's use 8080 as a common alternative for containers
+EXPOSE 8080
+
+# Command to serve the 'docs' directory
+# -s flag is important for single-page applications (SPA) to redirect all requests to index.html
+# -l flag specifies the listener port
+CMD ["serve", "-s", "docs", "-l", "8080"]


### PR DESCRIPTION
This commit introduces the ability to build and run the client application as a Docker container, and sets up a GitHub Actions workflow to automate the building and pushing of this image to Docker Hub.

The existing GitHub Pages deployment for the client will be kept for production, while the Docker image can be used for local testing (e.g., with Docker Compose) or alternative deployment scenarios.

Changes:
1.  **`client/Dockerfile` Created:**
    -   A new multi-stage `Dockerfile` was added in the `client` directory.
    -   The first stage (`builder`) uses `node:20-slim` to install
        dependencies (including Parcel) and run `npm run build`, which
        compiles the static assets into the `/app/client/docs` directory.
    -   The second stage (`runner`) uses a lightweight `node:20-alpine`
        image, installs `serve` globally, copies the built assets from the
        builder stage, exposes port 8080, and sets the `CMD` to
        `serve -s docs -l 8080` to serve the static content.

2.  **New GitHub Actions Workflow (`.github/workflows/client-docker-build.yml`):**
    -   A new workflow file was created to automate building the client
        Docker image and pushing it to Docker Hub.
    -   This workflow triggers on pushes to `main` affecting the `client/`
        directory or the workflow file itself, and also allows manual dispatch.
    -   It uses `docker/setup-buildx-action`, `docker/login-action` (with
        `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets), and
        `docker/build-push-action`.
    -   The image is tagged, for example, as
        `${{ secrets.DOCKERHUB_USERNAME }}/ping-client:latest`.

3.  **`README.md` Updated:**
    -   The "Deployment" section for the client application was updated to
        include instructions for the new Docker-based option.
    -   This includes commands for building and running the client Docker
        image locally.
    -   It also describes the new `client-docker-build.yml` GitHub Actions
        workflow and the required Docker Hub secrets.
    -   A note on `bffBaseUrl` configuration for the containerized client
        was added.

4.  **Coexistence of Deployments:**
    -   Confirmed that both the new Docker image deployment and the existing
        GitHub Pages deployment for the client will be maintained. The Docker
        image is intended primarily for local testing (e.g., with
        docker-compose), while GitHub Pages will continue to serve as the
        production deployment for the client.