### PR TITLE
feat: Allow client IDs to be set at Docker build time for SPA

### DIFF
--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build the static assets for the SPA
 FROM node:20-slim AS builder
 
+ARG VITE_STAFF_CLIENT_ID=your_staff_id_here
+ARG VITE_CUSTOMER_CLIENT_ID=your_customer_id_here
+
 WORKDIR /app/spa
 
 # Copy package.json and package-lock.json (if available)
@@ -14,6 +17,8 @@ COPY . .
 
 # Build the application
 # The output will be in the /app/spa/dist directory
+ENV VITE_STAFF_CLIENT_ID=${VITE_STAFF_CLIENT_ID}
+ENV VITE_CUSTOMER_CLIENT_ID=${VITE_CUSTOMER_CLIENT_ID}
 RUN npm run build
 
 # Stage 2: Serve the static assets from the 'dist' directory


### PR DESCRIPTION
I modified the spa/Dockerfile to accept VITE_STAFF_CLIENT_ID and VITE_CUSTOMER_CLIENT_ID as build arguments. These arguments are then used to set environment variables during the Vite build process.

This allows your Single Page Application to be built with specific client IDs embedded at the time the Docker image is created, rather than being hardcoded.

To build with custom IDs:
docker build \
  --build-arg VITE_STAFF_CLIENT_ID="<staff_id>" \
  --build-arg VITE_CUSTOMER_CLIENT_ID="<customer_id>" \
  -t my-spa-app ./spa