### PR TITLE
chore: Use GitHub Actions variables for SPA client IDs

### DIFF
--- a/.github/workflows/spa-docker-build.yml
+++ b/.github/workflows/spa-docker-build.yml
@@ -35,6 +35,9 @@ jobs:
           file: ./spa/Dockerfile # Path to the spa's Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/ping-spa:latest # Example image name, user can customize
+          build-args: |
+            VITE_STAFF_CLIENT_ID=${{ vars.VITE_STAFF_CLIENT_ID }}
+            VITE_CUSTOMER_CLIENT_ID=${{ vars.VITE_CUSTOMER_CLIENT_ID }}
           # To add more tags, like git sha:
           # tags: |
           #   ${{ secrets.DOCKERHUB_USERNAME }}/ping-spa:latest

--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build the static assets for the SPA
 FROM node:20-slim AS builder
 
+ARG VITE_STAFF_CLIENT_ID=your_staff_id_here
+ARG VITE_CUSTOMER_CLIENT_ID=your_customer_id_here
+
 WORKDIR /app/spa
 
 # Copy package.json and package-lock.json (if available)
@@ -14,6 +17,8 @@ COPY . .
 
 # Build the application
 # The output will be in the /app/spa/dist directory
+ENV VITE_STAFF_CLIENT_ID=${VITE_STAFF_CLIENT_ID}
+ENV VITE_CUSTOMER_CLIENT_ID=${VITE_CUSTOMER_CLIENT_ID}
 RUN npm run build
 
 # Stage 2: Serve the static assets from the 'dist' directory
@@ -29,7 +34,7 @@ COPY --from=builder /app/spa/dist ./content
 # (Serving from a subdirectory like 'content' rather than root of /app for clarity)
 
 # Expose the port 'serve' will listen on
-EXPOSE 1234
+EXPOSE 5173
 
 # Command to serve the 'content' directory (which contains the SPA's 'dist' output)
 # -s flag is important for single-page applications (SPA)


### PR DESCRIPTION
I updated the GitHub Actions workflow `.github/workflows/spa-docker-build.yml` to source the `VITE_STAFF_CLIENT_ID` and `VITE_CUSTOMER_CLIENT_ID` build arguments from GitHub Actions variables (`vars`) instead of secrets (`secrets`).

This change reflects that these particular client IDs are not considered sensitive and can be managed as repository or organization variables.