### PR TITLE
Fix: Correct OIDC issuer metadata conditionally

### DIFF
--- a/bff/server.js
+++ b/bff/server.js
@@ -55,14 +55,63 @@ async function startServer() {
       Issuer[custom.http_options] = (options) => ({ ...options, agent: customAgent });
     }
 
+    // Refined OIDC metadata correction function (Attempt 3)
+    function correctIssuerMetadata(metadata, expectedBaseUrlString) {
+      const newMetadata = JSON.parse(JSON.stringify(metadata)); // Deep copy
+      const expectedUrlObj = new URL(expectedBaseUrlString);
+
+      console.log('[OIDC Metadata Correction] Starting correction process. Expected base URL:', expectedBaseUrlString);
+
+      for (const key of Object.keys(newMetadata)) {
+        const currentValue = newMetadata[key];
+        if (typeof currentValue === 'string' && (currentValue.startsWith('http://localhost:') || currentValue.startsWith('https://localhost:'))) {
+          try {
+            let originalUrlObj = new URL(currentValue);
+            // Conditional Rewrite: Only change if original is localhost and expected is not localhost.
+            if (originalUrlObj.hostname === 'localhost' && expectedUrlObj.hostname !== 'localhost') {
+              originalUrlObj.protocol = expectedUrlObj.protocol;
+              originalUrlObj.hostname = expectedUrlObj.hostname;
+              originalUrlObj.port = expectedUrlObj.port;
+              newMetadata[key] = originalUrlObj.toString();
+              console.log(`[OIDC Metadata Correction] Conditionally corrected ${key}: ${currentValue} -> ${newMetadata[key]}`);
+            } else {
+              // console.log(`[OIDC Metadata Correction] No change needed for ${key} (${currentValue}) based on hostname conditions.`);
+            }
+          } catch (e) {
+            console.error(`[OIDC Metadata Correction] Error processing ${key} URL '${currentValue}': ${e.message}. Skipping this key.`);
+          }
+        }
+      }
+      console.log('[OIDC Metadata Correction] Finished correction process. Resulting metadata:', JSON.stringify(newMetadata, null, 2));
+      return newMetadata;
+    }
+
     Issuer.discover(pingIssuerUrl)
-      .then(issuer => {
+      .then(originalIssuer => { // Renamed to originalIssuer
         if (allowSelfSignedCerts) {
           Issuer[custom.http_options] = originalHttpOptions; // Restore after discovery
         }
-        console.log(`Discovered issuer ${issuer.issuer}`);
 
-        oidcClient = new issuer.Client({ // Assign to the higher-scoped variable
+        console.log('[OIDC Setup] Original issuer URL from discovery:', originalIssuer.issuer);
+        if (originalIssuer.metadata && originalIssuer.metadata.authorization_endpoint) {
+            console.log('[OIDC Setup] Original authorization_endpoint from discovery:', originalIssuer.metadata.authorization_endpoint);
+        } else {
+            console.log('[OIDC Setup] Original authorization_endpoint from discovery: Not found in metadata');
+        }
+
+        // Correct the issuer metadata using the refined strategy
+        const correctedMetadata = correctIssuerMetadata(originalIssuer.metadata, pingIssuerUrl);
+        const correctedIssuer = new Issuer(correctedMetadata); // Create new Issuer with corrected metadata
+
+        console.log('[OIDC Setup] Corrected issuer URL via new Issuer instance:', correctedIssuer.issuer);
+        if (correctedIssuer.metadata && correctedIssuer.metadata.authorization_endpoint) {
+            console.log('[OIDC Setup] Corrected authorization_endpoint via new Issuer instance:', correctedIssuer.metadata.authorization_endpoint);
+        } else {
+            console.log('[OIDC Setup] Corrected authorization_endpoint via new Issuer instance: Not found in metadata');
+        }
+        console.log(`Using issuer for OIDC client: ${correctedIssuer.issuer}`);
+
+        oidcClient = new correctedIssuer.Client({ // Use correctedIssuer
           client_id: clientId,
           client_secret: clientSecret,
           redirect_uris: [redirectUri],


### PR DESCRIPTION
This commit refines the OIDC issuer metadata correction in the BFF. The previous approach, while fixing the Docker scenario (where PING_ISSUER_URL is e.g. https://pf:9031), introduced an issue for local development (where PING_ISSUER_URL is https://localhost:9031). The issue was an `RPError: unexpected iss value` because the URL normalization slightly altered the 'issuer' URL string (e.g. adding a trailing slash), causing a mismatch with the ID token's 'iss' claim.

The updated logic in `correctIssuerMetadata` now implements a conditional rewrite:
1. It iterates through all discovered metadata properties.
2. If a metadata URL string points to 'localhost' (e.g., https://localhost:9031/...), it checks if the PING_ISSUER_URL (expectedBaseUrl) also points to 'localhost'.
3. URLs are only rewritten to use the PING_ISSUER_URL's scheme, host, and port IF the original metadata URL used 'localhost' AND PING_ISSUER_URL uses a DIFFERENT hostname (e.g., 'pf').
4. If PING_ISSUER_URL also uses 'localhost', the original metadata URL string is preserved exactly, preventing any normalization-induced mismatches.

Additionally, a new `Issuer` instance is created from the corrected metadata before the `Client` is instantiated. This ensures that all properties of the `Issuer` object (like `.issuer`, `.authorizationEndpoint`) reflect the corrected values, which are then used by the `Client`.

This approach ensures that:
- In Docker, 'localhost' URLs from PingFederate's discovery are correctly changed to the Docker-internal hostname (e.g., 'pf').
- Locally, 'localhost' URLs are preserved as is, maintaining exact string equality for issuer validation.