### PR TITLE
Refactor: Introduce PING_BROWSER_FACING_BASE_URL

### DIFF
--- a/bff/.env.example
+++ b/bff/.env.example
@@ -1,7 +1,22 @@
 # PingFederate OIDC Configuration
 PING_CLIENT_ID="your_ping_client_id_for_bff"
 PING_CLIENT_SECRET="your_ping_client_secret_for_bff"
+
+# Base URL for PingFederate that the BFF uses for direct server-to-server communication
+# (e.g., token exchange, userinfo). In Docker Compose, this might be an internal service name.
+# Example for Docker: https://pf:9031
+# Example for local:  https://localhost:9031
 PING_ISSUER_URL="https://ping.hdc.company"
+
+# (Optional) Base URL for PingFederate that the user's BROWSER will be redirected to,
+# specifically for endpoints like the authorization endpoint.
+# This is mainly for Dockerized test/dev environments where the browser (outside Docker)
+# needs to reach PingFederate via a different URL (e.g., localhost mapped to a Docker service)
+# than the BFF (inside Docker) uses for server-to-server calls.
+# If unset, or if the same as PING_ISSUER_URL, the corrected PING_ISSUER_URL (after potential
+# localhost correction for BFF's internal calls) will be used for browser-facing redirects as well.
+# Example for Docker test env: https://localhost:9031 (if host's localhost:9031 maps to PingFederate)
+PING_BROWSER_FACING_BASE_URL=""
 
 # Session Configuration
 SESSION_SECRET="a_very_long_random_and_secure_string_for_session_signing"


### PR DESCRIPTION
This commit introduces a new environment variable `PING_BROWSER_FACING_BASE_URL` and updates the OIDC metadata correction logic in `bff/server.js` to support scenarios, particularly in Dockerized test environments, where the base URL for PingFederate used by the browser needs to be different from the base URL used by the BFF for server-to-server communication.

Changes:
- Added `PING_BROWSER_FACING_BASE_URL` to `bff/.env.example` with documentation.
- `bff/server.js` now reads this new environment variable.
- The `correctIssuerMetadata` function has been updated:
    - It now accepts an additional `browserFacingBaseUrlString` argument.
    - For specific browser-facing OIDC endpoints (e.g., `authorization_endpoint`, `end_session_endpoint`), if `PING_BROWSER_FACING_BASE_URL` is provided, these endpoints are reconstructed using this URL as their base.
    - For other OIDC endpoints, or if `PING_BROWSER_FACING_BASE_URL` is not set, the existing conditional correction logic is applied (i.e., `localhost` URLs are updated to `PING_ISSUER_URL`'s hostname if it's different, otherwise preserved).
- This allows the BFF to generate correct redirect URLs for the browser (e.g., using `https://localhost:9031` which maps to PingFederate in Docker) while still using internal Docker hostnames (e.g., `https://pf:9031`) for direct BFF-to-PingFederate calls.