### PR TITLE
feat: Add placeholder favicons and serving mechanisms

### DIFF
--- a/bff/favicon.ico
+++ b/bff/favicon.ico
@@ -1,0 +1,1 @@
+BFF Favicon Placeholder

--- a/bff/server.js
+++ b/bff/server.js
@@ -7,6 +7,7 @@ const { Issuer, custom } = require('openid-client');
 const https = require('https');
 const crypto = require('crypto');
 const cors = require('cors'); // Moved to top-level requires
+const path = require('path');
 
 const app = express(); // Define app instance at a higher scope
 let oidcClient; // Define oidcClient at a higher scope
@@ -230,6 +231,11 @@ async function startServer() {
             sameSite: isProduction ? 'None' : 'Lax'
           }
         }));
+
+        // Favicon serving
+        app.get('/favicon.ico', (req, res) => {
+          res.sendFile(path.join(__dirname, 'favicon.ico'));
+        });
 
         // --- Express Routes ---
         const requestedScopes = ['openid', 'profile', 'email'];

--- a/client/favicon.ico
+++ b/client/favicon.ico
@@ -1,0 +1,1 @@
+Client Favicon Placeholder

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Client App with BFF Auth</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/spa/index.html
+++ b/spa/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Minimal Node.js Entra ID Authentication App</title>
   </head>

--- a/spa/public/favicon.ico
+++ b/spa/public/favicon.ico
@@ -1,0 +1,1 @@
+SPA Favicon Placeholder


### PR DESCRIPTION
Adds placeholder favicon.ico files to the bff, client, and spa applications to prevent 404 errors and allow for future theming.

Changes include:
- Created bff/favicon.ico, client/favicon.ico, and spa/public/favicon.ico (currently text placeholders).
- Modified client/index.html to link to /favicon.ico.
- Modified spa/index.html to link to /favicon.ico, replacing the previous vite.svg icon.
- Modified bff/server.js to serve bff/favicon.ico on GET /favicon.ico.

This sets up the infrastructure for favicons. The placeholder files can be replaced with actual themed icons as a next step. The client and BFF are intended to share one theme, and the SPA another.