### PR TITLE
Gracefully handle undefined environment variables during login to prevent uncaught TypeErrors

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -144,7 +144,20 @@ function App() {
   };
 
   const handleLogin = async (clientId: string) => {
-    await redirectToAuth(clientId);
+    try {
+      if (!clientId) {
+        throw new Error('VITE_STAFF_CLIENT_ID is not defined. Please check your environment configuration.');
+      }
+      await redirectToAuth(clientId);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : 'Login failed';
+      setOAuthError({
+        error: 'Configuration Error',
+        description: errorMsg,
+        clientId: clientId || undefined,
+        redirectUri,
+      });
+    }
   };
 
   const handleCheckToken = async () => {

--- a/spa/src/lib/__tests__/tokenExchange.test.ts
+++ b/spa/src/lib/__tests__/tokenExchange.test.ts
@@ -29,6 +29,11 @@ describe('resolveTokenEndpoint', () => {
       'https://ping.example.com/as/token.oauth2',
     );
   });
+
+  it('throws error if pingBaseUrl is falsy/undefined', () => {
+    expect(() => resolveTokenEndpoint('')).toThrow('pingBaseUrl is required');
+    expect(() => resolveTokenEndpoint(undefined as any)).toThrow('pingBaseUrl is required');
+  });
 });
 
 describe('resolveAuthEndpoint', () => {
@@ -48,6 +53,11 @@ describe('resolveAuthEndpoint', () => {
       'https://ping.example.com/as/authorization.oauth2',
     );
   });
+
+  it('throws error if pingBaseUrl is falsy/undefined', () => {
+    expect(() => resolveAuthEndpoint('')).toThrow('pingBaseUrl is required');
+    expect(() => resolveAuthEndpoint(undefined as any)).toThrow('pingBaseUrl is required');
+  });
 });
 
 describe('resolveLogoffEndpoint', () => {
@@ -61,6 +71,11 @@ describe('resolveLogoffEndpoint', () => {
     expect(resolveLogoffEndpoint('https://ping.example.com/as/token.oauth2')).toBe(
       'https://ping.example.com/idp/startSLO.ping',
     );
+  });
+
+  it('throws error if pingBaseUrl is falsy/undefined', () => {
+    expect(() => resolveLogoffEndpoint('')).toThrow('pingBaseUrl is required');
+    expect(() => resolveLogoffEndpoint(undefined as any)).toThrow('pingBaseUrl is required');
   });
 });
 

--- a/spa/src/lib/tokenExchange.ts
+++ b/spa/src/lib/tokenExchange.ts
@@ -6,6 +6,9 @@ export interface TokenResponse {
 }
 
 export function resolveTokenEndpoint(pingBaseUrl: string): string {
+  if (!pingBaseUrl) {
+    throw new Error('pingBaseUrl is required');
+  }
   if (pingBaseUrl.includes('/as/token.oauth2')) {
     return pingBaseUrl;
   }
@@ -16,6 +19,9 @@ export function resolveTokenEndpoint(pingBaseUrl: string): string {
 }
 
 export function resolveAuthEndpoint(pingBaseUrl: string): string {
+  if (!pingBaseUrl) {
+    throw new Error('pingBaseUrl is required');
+  }
   if (pingBaseUrl.includes('/as/authorization.oauth2')) {
     return pingBaseUrl;
   }
@@ -23,6 +29,9 @@ export function resolveAuthEndpoint(pingBaseUrl: string): string {
 }
 
 export function resolveLogoffEndpoint(pingBaseUrl: string): string {
+  if (!pingBaseUrl) {
+    throw new Error('pingBaseUrl is required');
+  }
   const baseUrl = pingBaseUrl.split('/as/')[0];
   return `${baseUrl}/idp/startSLO.ping`;
 }


### PR DESCRIPTION
This PR resolves a TypeError (`Cannot read properties of undefined (reading 'includes')`) that occurs when a user clicks the "Vendor Sign-in" button on the SPA client when required environment variables (such as `VITE_PING_BASE_URL`) are undefined or not populated at build time.

### Key Changes:
- **`spa/src/lib/tokenExchange.ts`**:
  - Added strict parameter checks to `resolveTokenEndpoint`, `resolveAuthEndpoint`, and `resolveLogoffEndpoint` to throw an explicit and clear Error if `pingBaseUrl` is not provided.
- **`spa/src/App.tsx`**:
  - Wrapped `handleLogin` inside a `try/catch` block to handle both missing Client ID (`VITE_STAFF_CLIENT_ID`) and errors thrown by `redirectToAuth`.
  - When caught, the error is gracefully mapped to the custom error state, showing a beautiful and helpful full-page "Configuration Error" UI instead of crashing the React application with an uncaught runtime exception.
- **`spa/src/lib/__tests__/tokenExchange.test.ts`**:
  - Added new unit test cases to verify error-handling and validation behavior for all token endpoint resolving helper functions.

---
*PR created automatically by Jules for task [5808990094547945254](https://jules.google.com/task/5808990094547945254) started by @jules-hdc*